### PR TITLE
CAF-3862: Update to use new opensuse-elasticsearch image

### DIFF
--- a/configureElasticsearch.sh
+++ b/configureElasticsearch.sh
@@ -147,7 +147,7 @@ function configure_elasticsearch_user_for_memlock(){
 function replace_elasticsearch_config_file(){
 
     set_elasticsearch_config_file_location
-    mv -f ${elasticsearchConfigFile} /etc/elasticsearch/elasticsearch.yml
+    mv -f ${elasticsearchConfigFile} /opt/elasticsearch/config/elasticsearch.yml
 }
 
 
@@ -157,7 +157,7 @@ function replace_elasticsearch_config_file(){
 function replace_elasticsearch_logging_file(){
 
     set_elasticsearch_logging_file_location
-    mv -f ${elasticsearchLoggingFile} /etc/elasticsearch/logging.yml
+    mv -f ${elasticsearchLoggingFile} /opt/elasticsearch/config/logging.yml
 }
 
 ####################################################

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                             <alias>elasticsearch</alias>
                             <name>${dockerCafDataProcessingOrg}policy-elasticsearch-container${dockerProjectVersion}</name>
                             <build>
-                                <from>java:8</from>
+                                <from>cafapi/opensuse-jre8:1.2</from>
                                 <nocache>true</nocache>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
                                 <runCmds>
                                     <runcmd>zypper -n install wget dpkg</runcmd>
                                     <runcmd>cd /opt</runcmd>
-                                    <runcmd>wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${elasticsearch-version}/elasticsearch-${elasticsearch-version}.deb</runcmd>
-                                    <runcmd>dpkg -i elasticsearch-${elasticsearch-version}.deb</runcmd>
-                                    <runcmd>chkconfig --set elasticsearch defaults 95 10</runcmd>
+                                    <runcmd>wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch-version}.rpm</runcmd>
+                                    <runcmd>rpm --install elasticsearch-${elasticsearch-version}.rpm</runcmd>
+                                    <runcmd>chkconfig --add elasticsearch</runcmd>
                                     <runcmd>/usr/share/elasticsearch/bin/plugin install analysis-icu</runcmd>
                                 </runCmds>
                                 <assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
                                     <runcmd>cd /opt</runcmd>
                                     <runcmd>wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${elasticsearch-version}/elasticsearch-${elasticsearch-version}.deb</runcmd>
                                     <runcmd>dpkg -i elasticsearch-${elasticsearch-version}.deb</runcmd>
-                                    <runcmd>update-rc.d elasticsearch defaults 95 10</runcmd>
+                                    <runcmd>chkconfig --set elasticsearch defaults 95 10</runcmd>
                                     <runcmd>/usr/share/elasticsearch/bin/plugin install analysis-icu</runcmd>
                                 </runCmds>
                                 <assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
                                 <runCmds>
                                     <runcmd>zypper -n install which hostname</runcmd>
                                     <runcmd>cd /opt</runcmd>
-                                    <runcmd>curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/{elasticsearch-version}/elasticsearch-{elasticsearch-version}.rpm</runcmd>
+                                    <runcmd>curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/${elasticsearch-version}/elasticsearch-${elasticsearch-version}.rpm</runcmd>
                                     <runcmd>rpm --install elasticsearch-${elasticsearch-version}.rpm</runcmd>
                                     <runcmd>/usr/share/elasticsearch/bin/plugin install analysis-icu</runcmd>
                                 </runCmds>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
     </developers>
 
     <properties>
-        <elasticsearch-version>2.3.3</elasticsearch-version>
         <fileSet.outputDirectory>elasticsearchConfig</fileSet.outputDirectory>
         <dockerHubOrganization>cafdataprocessing</dockerHubOrganization>
         <dockerCafDataProcessingOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafDataProcessingOrg>
@@ -130,7 +129,7 @@
                             <alias>elasticsearch</alias>
                             <name>${dockerCafDataProcessingOrg}policy-elasticsearch-container${dockerProjectVersion}</name>
                             <build>
-                                <from>cafapi/opensuse-jre8:1.2</from>
+                                <from>cafinternal/prereleases:opensuse-elasticsearch2-1.0.0-SNAPSHOT</from>
                                 <nocache>true</nocache>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
@@ -139,13 +138,6 @@
                                     <Git.Commit>${git.revision}</Git.Commit>
                                 </labels>
                                 <optimise>true</optimise>
-                                <runCmds>
-                                    <runcmd>zypper -n install which hostname</runcmd>
-                                    <runcmd>cd /opt</runcmd>
-                                    <runcmd>curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/${elasticsearch-version}/elasticsearch-${elasticsearch-version}.rpm</runcmd>
-                                    <runcmd>rpm --install elasticsearch-${elasticsearch-version}.rpm</runcmd>
-                                    <runcmd>/usr/share/elasticsearch/bin/plugin install analysis-icu</runcmd>
-                                </runCmds>
                                 <assembly>
                                     <basedir>/opt</basedir>
                                     <mode>tar</mode>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
                                 <runCmds>
                                     <runcmd>zypper -n install wget dpkg</runcmd>
                                     <runcmd>cd /opt</runcmd>
-                                    <runcmd>wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch-version}.rpm</runcmd>
+                                    <runcmd>wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/{elasticsearch-version}/elasticsearch-{elasticsearch-version}.rpm</runcmd>
                                     <runcmd>rpm --install elasticsearch-${elasticsearch-version}.rpm</runcmd>
                                     <runcmd>chkconfig --add elasticsearch</runcmd>
                                     <runcmd>/usr/share/elasticsearch/bin/plugin install analysis-icu</runcmd>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
 
     <groupId>com.github.cafdataprocessing</groupId>
     <artifactId>policy-elasticsearch-container</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
-        <version>1.11.0-218</version>
+        <version>1.15.0-1</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,11 +140,10 @@
                                 </labels>
                                 <optimise>true</optimise>
                                 <runCmds>
-                                    <runcmd>zypper -n install wget dpkg</runcmd>
+                                    <runcmd>zypper -n install which hostname</runcmd>
                                     <runcmd>cd /opt</runcmd>
-                                    <runcmd>wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/{elasticsearch-version}/elasticsearch-{elasticsearch-version}.rpm</runcmd>
+                                    <runcmd>curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/{elasticsearch-version}/elasticsearch-{elasticsearch-version}.rpm</runcmd>
                                     <runcmd>rpm --install elasticsearch-${elasticsearch-version}.rpm</runcmd>
-                                    <runcmd>chkconfig --add elasticsearch</runcmd>
                                     <runcmd>/usr/share/elasticsearch/bin/plugin install analysis-icu</runcmd>
                                 </runCmds>
                                 <assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
                                 </labels>
                                 <optimise>true</optimise>
                                 <runCmds>
+                                    <runcmd>zypper -n install wget dpkg</runcmd>
                                     <runcmd>cd /opt</runcmd>
                                     <runcmd>wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${elasticsearch-version}/elasticsearch-${elasticsearch-version}.deb</runcmd>
                                     <runcmd>dpkg -i elasticsearch-${elasticsearch-version}.deb</runcmd>

--- a/release-notes-1.2.0.md
+++ b/release-notes-1.2.0.md
@@ -1,8 +1,0 @@
-!not-ready-for-release!
-
-#### Version Number
-${version-number}
-
-#### New Features
-
-#### Known Issues

--- a/release-notes-2.0.0.md
+++ b/release-notes-2.0.0.md
@@ -8,4 +8,4 @@ ${version-number}
 #### Known Issues
 
 #### Breaking Change
-The image has been updated to use the [opensuse-elasticsearch2-image](https://github.com/CAFapi/opensuse-elasticsearch2-image) as its base image. This means that the underlying operating system is now openSUSE and as such any projects consuming this image will require changes to the caller.
+- The image has been updated to use the [opensuse-elasticsearch2-image](https://github.com/CAFapi/opensuse-elasticsearch2-image) as its base image. This means that the underlying operating system is now openSUSE and as such any projects consuming this image may require changes to the caller. For example, if the consuming project is using Debian tools like apt-get then updates would be required.

--- a/release-notes-2.0.0.md
+++ b/release-notes-2.0.0.md
@@ -1,0 +1,11 @@
+!not-ready-for-release!
+
+#### Version Number
+${version-number}
+
+#### New Features
+
+#### Known Issues
+
+#### Breaking Change
+The image has been updated to use the [opensuse-elasticsearch2-image](https://github.com/CAFapi/opensuse-elasticsearch2-image) as its base image. This means that the underlying operating system is now openSUSE and as such any projects consuming this image will require changes to the caller.


### PR DESCRIPTION
Dev build: http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~policy-elasticsearch-container~CAF-3862~CI/

This has been consumed by policy server in CAF-3862 branch here: https://github.com/CAFDataProcessing/policy-server/tree/CAF-3862
Dev build for this: http://sou-jenkins2.hpeswlab.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~policy-server~CAF-3862~CI/